### PR TITLE
Add configurable link text and improve title detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Plugin WordPress che permette di creare link diretti a WhatsApp seguendo le indi
 
 - Configura il numero di telefono internazionale destinatario dei messaggi.
 - Aggiungi un breve testo introduttivo che verrà inserito prima del titolo del post nel messaggio precompilato.
+- Imposta il testo che sarà mostrato insieme al link generato dallo shortcode.
 - Inserisci lo shortcode `[send_whatsapp_link]` ovunque nei contenuti per mostrare il link.
 - Il link generato apre una chat WhatsApp con il numero configurato e precompila il messaggio con "Testo breve + Titolo del post".
 
@@ -16,6 +17,7 @@ Plugin WordPress che permette di creare link diretti a WhatsApp seguendo le indi
 3. Accedi alla voce **Send WhatsApp → Configurazione** nel menu di amministrazione e inserisci:
    - Il numero di telefono completo di prefisso internazionale (solo cifre, senza simboli o spazi).
    - Un breve testo opzionale da aggiungere prima del titolo del post nel messaggio.
+   - Un testo opzionale da visualizzare accanto al link generato.
 4. Salva le impostazioni.
 5. Aggiungi lo shortcode `[send_whatsapp_link]` dove desideri che appaia il link all'interno dei tuoi contenuti.
 

--- a/send-whatsapp.php
+++ b/send-whatsapp.php
@@ -16,6 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 define( 'SEND_WHATSAPP_OPTION_PHONE', 'send_whatsapp_phone_number' );
 define( 'SEND_WHATSAPP_OPTION_PREFIX', 'send_whatsapp_text_prefix' );
 define( 'SEND_WHATSAPP_SHORTCODE', 'send_whatsapp_link' );
+define( 'SEND_WHATSAPP_OPTION_LINK_TEXT', 'send_whatsapp_link_text' );
 
 add_action( 'admin_menu', 'send_whatsapp_register_menu' );
 add_action( 'admin_init', 'send_whatsapp_register_settings' );
@@ -45,6 +46,12 @@ function send_whatsapp_register_settings() {
     ] );
 
     register_setting( 'send_whatsapp_settings_group', SEND_WHATSAPP_OPTION_PREFIX, [
+        'type'              => 'string',
+        'sanitize_callback' => 'sanitize_text_field',
+        'default'           => '',
+    ] );
+
+    register_setting( 'send_whatsapp_settings_group', SEND_WHATSAPP_OPTION_LINK_TEXT, [
         'type'              => 'string',
         'sanitize_callback' => 'sanitize_text_field',
         'default'           => '',
@@ -80,8 +87,9 @@ function send_whatsapp_render_settings_page() {
         return;
     }
 
-    $phone  = get_option( SEND_WHATSAPP_OPTION_PHONE, '' );
-    $prefix = get_option( SEND_WHATSAPP_OPTION_PREFIX, '' );
+    $phone     = get_option( SEND_WHATSAPP_OPTION_PHONE, '' );
+    $prefix    = get_option( SEND_WHATSAPP_OPTION_PREFIX, '' );
+    $link_text = get_option( SEND_WHATSAPP_OPTION_LINK_TEXT, '' );
     ?>
     <div class="wrap">
         <h1><?php esc_html_e( 'Configurazione', 'send-whatsapp' ); ?></h1>
@@ -104,6 +112,14 @@ function send_whatsapp_render_settings_page() {
                     </th>
                     <td>
                         <input type="text" id="send_whatsapp_text_prefix" name="<?php echo esc_attr( SEND_WHATSAPP_OPTION_PREFIX ); ?>" value="<?php echo esc_attr( $prefix ); ?>" class="regular-text" placeholder="Scrivi il tuo messaggio: " />
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row">
+                        <label for="send_whatsapp_link_text"><?php esc_html_e( 'Testo da mostrare insieme al link', 'send-whatsapp' ); ?></label>
+                    </th>
+                    <td>
+                        <input type="text" id="send_whatsapp_link_text" name="<?php echo esc_attr( SEND_WHATSAPP_OPTION_LINK_TEXT ); ?>" value="<?php echo esc_attr( $link_text ); ?>" class="regular-text" placeholder="Contattaci su WhatsApp" />
                     </td>
                 </tr>
                 </tbody>
@@ -134,11 +150,12 @@ function send_whatsapp_generate_url( $post_id = null ) {
         $post_id = get_the_ID();
     }
 
-    if ( ! $post_id ) {
+    $title = send_whatsapp_get_content_title( $post_id ? $post_id : null );
+
+    if ( '' === $title ) {
         return '';
     }
 
-    $title       = get_the_title( $post_id );
     $prefix_text = get_option( SEND_WHATSAPP_OPTION_PREFIX, '' );
     $message     = trim( $prefix_text . ' ' . $title );
     $message     = wp_strip_all_tags( $message );
@@ -157,6 +174,42 @@ function send_whatsapp_generate_url( $post_id = null ) {
  *
  * @return string
  */
+function send_whatsapp_get_content_title( $post_id = null ) {
+    if ( null !== $post_id && $post_id ) {
+        $title = get_the_title( $post_id );
+
+        if ( '' !== $title ) {
+            return $title;
+        }
+    }
+
+    $queried_object = get_queried_object();
+
+    if ( $queried_object instanceof \WP_Post ) {
+        $title = get_the_title( $queried_object );
+
+        if ( '' !== $title ) {
+            return $title;
+        }
+    }
+
+    if ( $queried_object instanceof \WP_Term ) {
+        return $queried_object->name;
+    }
+
+    if ( $queried_object instanceof \WP_User ) {
+        return $queried_object->display_name;
+    }
+
+    $title = single_post_title( '', false );
+
+    if ( '' !== $title ) {
+        return $title;
+    }
+
+    return get_bloginfo( 'name', 'display' );
+}
+
 function send_whatsapp_shortcode_handler() {
     $url = send_whatsapp_generate_url();
 
@@ -164,13 +217,19 @@ function send_whatsapp_shortcode_handler() {
         return '';
     }
 
-    $post_id = get_the_ID();
-    $title   = get_the_title( $post_id );
+    $post_id     = get_the_ID();
+    $title       = send_whatsapp_get_content_title( $post_id );
+    $link_text   = get_option( SEND_WHATSAPP_OPTION_LINK_TEXT, '' );
+    $display_text = trim( $link_text . ' ' . $title );
+
+    if ( '' === $display_text ) {
+        $display_text = __( 'Apri chat WhatsApp', 'send-whatsapp' );
+    }
 
     return sprintf(
         '<a href="%1$s" target="_blank" rel="noopener noreferrer">%2$s</a>',
         esc_url( $url ),
-        esc_html( $title )
+        esc_html( $display_text )
     );
 }
 add_shortcode( SEND_WHATSAPP_SHORTCODE, 'send_whatsapp_shortcode_handler' );


### PR DESCRIPTION
## Summary
- add a configurable option to define the text displayed alongside the WhatsApp link
- extend the shortcode and message generation to combine the configured text with the resolved content title
- introduce a helper that retrieves a meaningful title across posts, terms, and users so the link works on any content type

## Testing
- php -l send-whatsapp.php

------
https://chatgpt.com/codex/tasks/task_e_68ca821292ac8332896f305cb78809f4