### PR TITLE
Adjust link text to use custom label only

### DIFF
--- a/send-whatsapp.php
+++ b/send-whatsapp.php
@@ -217,13 +217,12 @@ function send_whatsapp_shortcode_handler() {
         return '';
     }
 
-    $post_id     = get_the_ID();
-    $title       = send_whatsapp_get_content_title( $post_id );
-    $link_text   = get_option( SEND_WHATSAPP_OPTION_LINK_TEXT, '' );
-    $display_text = trim( $link_text . ' ' . $title );
+    $link_text = get_option( SEND_WHATSAPP_OPTION_LINK_TEXT, '' );
 
-    if ( '' === $display_text ) {
+    if ( '' === $link_text ) {
         $display_text = __( 'Apri chat WhatsApp', 'send-whatsapp' );
+    } else {
+        $display_text = $link_text;
     }
 
     return sprintf(


### PR DESCRIPTION
## Summary
- simplify shortcode handler so the rendered link shows only the configured link text
- keep the default fallback message when no custom text is provided

## Testing
- php -l send-whatsapp.php

------
https://chatgpt.com/codex/tasks/task_e_68ca83ad7148833298bbe58510a793c0