### PR TITLE
Add margin bottom to WhatsApp button

### DIFF
--- a/send-whatsapp.php
+++ b/send-whatsapp.php
@@ -510,6 +510,7 @@ function send_whatsapp_enqueue_frontend_styles() {
         'font-weight:600;' .
         'transition:background-color 0.2s ease-in-out;' .
         'box-shadow:0 2px 4px rgba(0,0,0,0.1);' .
+        'margin-bottom:15px;' .
         '}' .
         '.send-whatsapp-button:hover,' .
         '.send-whatsapp-button:focus{' .


### PR DESCRIPTION
## Summary
- add a 15px bottom margin to the WhatsApp button style to improve spacing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca928eccb88332b7cffda59c0e7f9c